### PR TITLE
feat: refactor typing display components for unified type usage

### DIFF
--- a/apps/web/src/features/typing/components/sentence-display.tsx
+++ b/apps/web/src/features/typing/components/sentence-display.tsx
@@ -1,24 +1,9 @@
-type SentenceCharacter = {
-  label: string;
-};
+import type { Sentence } from "@dakenjin/core";
 
 type SentenceDisplayProps = {
-  characters: SentenceCharacter[];
+  sentence: Sentence;
 };
 
-export function SentenceDisplay({ characters }: SentenceDisplayProps) {
-  return (
-    <div className="space-y-1">
-      <div className="text-2xl text-gray-800">
-        {characters.map((character, index) => (
-          <span key={index}>{character.label}</span>
-        ))}
-      </div>
-      <div className="text-sm text-gray-500">
-        {characters.map((character, index) => (
-          <span key={index}>{character.label}</span>
-        ))}
-      </div>
-    </div>
-  );
+export function SentenceDisplay({ sentence }: SentenceDisplayProps) {
+  return <div className="text-2xl text-gray-800">{sentence.label}</div>;
 }

--- a/apps/web/src/features/typing/components/session-input.tsx
+++ b/apps/web/src/features/typing/components/session-input.tsx
@@ -62,7 +62,7 @@ export function SessionInput({ sentences, onComplete }: SessionInputProps) {
                 currentCharacter ? 1 : 0,
               )}
             />
-            <SentenceDisplay characters={currentSentence.characters} />
+            <SentenceDisplay sentence={currentSentence} />
           </div>
         </div>
       )}

--- a/apps/web/src/features/typing/components/typing-display.tsx
+++ b/apps/web/src/features/typing/components/typing-display.tsx
@@ -1,18 +1,12 @@
-type CompletedCharacter = {
-  inputs: string;
-};
-
-type CurrentCharacter = {
-  label: string;
-};
+import type { Character } from "@dakenjin/core";
 
 type TypingDisplayProps = {
-  completedCharacters: CompletedCharacter[];
-  currentCharacter: CurrentCharacter | null;
+  completedCharacters: Character[];
+  currentCharacter: Character | null;
   currentInputs: string;
   suggestions: string[];
   error: boolean;
-  futureCharacters: { getSuggestions: () => string[] }[];
+  futureCharacters: Character[];
 };
 
 export function TypingDisplay({
@@ -26,35 +20,54 @@ export function TypingDisplay({
   const firstSuggestion = suggestions[0] || "";
 
   return (
-    <div className="flex flex-wrap justify-center gap-2">
-      {completedCharacters.map((character, index) => (
-        <span key={index} className="text-lg font-mono text-green-500">
-          {character.inputs}
-        </span>
-      ))}
-      {currentCharacter && (
-        <div
-          className={`text-lg font-mono inline-flex ${
-            error ? "animate-pulse" : ""
-          }`}
-        >
-          <span className="text-green-500">{currentInputs}</span>
-          <span className={error ? "text-red-400" : "text-gray-400"}>
-            {firstSuggestion}
+    <div className="space-y-2">
+      <div className="flex flex-wrap justify-center gap-0.5">
+        {completedCharacters.map((character, index) => (
+          <span key={index} className="text-lg font-mono text-green-500">
+            {character.inputs}
           </span>
-        </div>
-      )}
-      {futureCharacters.map((character, index) => {
-        const futureSuggestions = character.getSuggestions();
-        return (
-          <span
-            key={`future-${index}`}
-            className="text-lg font-mono text-gray-400"
+        ))}
+        {currentCharacter && (
+          <div
+            className={`text-lg font-mono inline-flex ${
+              error ? "animate-pulse" : ""
+            }`}
           >
-            {futureSuggestions[0] || ""}
+            <span className="text-green-500">{currentInputs}</span>
+            <span className={error ? "text-red-400" : "text-gray-400"}>
+              {firstSuggestion}
+            </span>
+          </div>
+        )}
+        {futureCharacters.map((character, index) => {
+          const futureSuggestions = character.getSuggestions();
+          return (
+            <span
+              key={`future-${index}`}
+              className="text-lg font-mono text-gray-400"
+            >
+              {futureSuggestions[0] || ""}
+            </span>
+          );
+        })}
+      </div>
+      <div className="flex flex-wrap justify-center gap-0.5">
+        {completedCharacters.map((character, index) => (
+          <span key={`label-${index}`} className="text-lg text-green-500">
+            {character.label}
           </span>
-        );
-      })}
+        ))}
+        {currentCharacter && (
+          <span className="text-lg text-gray-400">
+            {currentCharacter.label}
+          </span>
+        )}
+        {futureCharacters.map((character, index) => (
+          <span key={`future-label-${index}`} className="text-lg text-gray-400">
+            {character.label}
+          </span>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Refactor typing-display.tsx to use Character type throughout instead of custom interfaces
- Add dual display showing both romaji inputs and Japanese character labels
- Update sentence-display.tsx to use sentence.label directly for cleaner implementation
- Improve type consistency across typing components

## Test plan
- [ ] Verify typing display shows both romaji and Japanese characters
- [ ] Confirm sentence display shows correct sentence labels
- [ ] Test that error states and animations work correctly
- [ ] Ensure all typing interactions function as expected

🤖 Generated with [Claude Code](https://claude.ai/code)