### PR TITLE
fix: remove text color from sentence display component

### DIFF
--- a/apps/web/src/features/typing/components/sentence-display.tsx
+++ b/apps/web/src/features/typing/components/sentence-display.tsx
@@ -5,5 +5,5 @@ type SentenceDisplayProps = {
 };
 
 export function SentenceDisplay({ sentence }: SentenceDisplayProps) {
-  return <div className="text-2xl text-gray-800">{sentence.label}</div>;
+  return <div className="text-2xl">{sentence.label}</div>;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Remove hardcoded gray text color from SentenceDisplay component to allow flexible styling

## Test plan
- [ ] Verify that SentenceDisplay component renders without the gray text color
- [ ] Check that parent components can apply their own text color styles

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)