### PR TITLE
feat: add CharacterSetFactory for simplified CharacterSet creation

### DIFF
--- a/packages/core/src/character-set-factory.test.ts
+++ b/packages/core/src/character-set-factory.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { CharacterSetFactory } from "./character-set-factory";
+import { Character } from "./character";
+
+describe("CharacterSetFactory", () => {
+  const createJapaneseCharacters = () => [
+    new Character({ label: "こ", inputPatterns: ["ko"] }),
+    new Character({ label: "ん", inputPatterns: ["nn", "n"] }),
+    new Character({ label: "に", inputPatterns: ["ni"] }),
+    new Character({ label: "ち", inputPatterns: ["chi", "ti"] }),
+    new Character({ label: "は", inputPatterns: ["ha"] }),
+    new Character({ label: "あ", inputPatterns: ["a"] }),
+    new Character({ label: "きゃ", inputPatterns: ["kya"] }),
+  ];
+
+  describe("constructor", () => {
+    it("should create a CharacterSetFactory with characters", () => {
+      const characters = [
+        new Character({ label: "あ", inputPatterns: ["a"] }),
+        new Character({ label: "い", inputPatterns: ["i"] }),
+      ];
+      const factory = new CharacterSetFactory(characters);
+      expect(factory).toBeInstanceOf(CharacterSetFactory);
+    });
+  });
+
+  describe("fromText", () => {
+    it("should create a CharacterSet from Japanese text", () => {
+      const characters = createJapaneseCharacters();
+      const factory = new CharacterSetFactory(characters);
+      const characterSet = factory.fromText("こんにちは");
+
+      expect(characterSet.characters).toHaveLength(5);
+      expect(characterSet.characters[0].label).toBe("こ");
+      expect(characterSet.characters[1].label).toBe("ん");
+      expect(characterSet.characters[2].label).toBe("に");
+      expect(characterSet.characters[3].label).toBe("ち");
+      expect(characterSet.characters[4].label).toBe("は");
+    });
+
+    it("should handle single character text", () => {
+      const characters = createJapaneseCharacters();
+      const factory = new CharacterSetFactory(characters);
+      const characterSet = factory.fromText("あ");
+
+      expect(characterSet.characters).toHaveLength(1);
+      expect(characterSet.characters[0].label).toBe("あ");
+    });
+
+    it("should handle complex characters like きゃ", () => {
+      const characters = createJapaneseCharacters();
+      const factory = new CharacterSetFactory(characters);
+      const characterSet = factory.fromText("きゃ");
+
+      expect(characterSet.characters).toHaveLength(1);
+      expect(characterSet.characters[0].label).toBe("きゃ");
+      expect(characterSet.characters[0].inputPatterns).toContain("kya");
+    });
+  });
+});

--- a/packages/core/src/character-set-factory.ts
+++ b/packages/core/src/character-set-factory.ts
@@ -1,0 +1,39 @@
+import { Character } from "./character";
+import { CharacterSet } from "./character-set";
+
+export class CharacterSetFactory {
+  private _characters: Character[];
+
+  constructor(characters: Character[]) {
+    this._characters = characters;
+  }
+
+  fromText(text: string): CharacterSet {
+    const characters: Character[] = [];
+    let i = 0;
+
+    while (i < text.length) {
+      let matched = false;
+
+      for (const character of [...this._characters].reverse()) {
+        if (text.slice(i, i + character.label.length) === character.label) {
+          characters.push(
+            new Character({
+              label: character.label,
+              inputPatterns: [...character.inputPatterns],
+            }),
+          );
+          i += character.label.length;
+          matched = true;
+          break;
+        }
+      }
+
+      if (!matched) {
+        throw new Error(`Unsupported character: ${text[i]} at position ${i}`);
+      }
+    }
+
+    return new CharacterSet(characters);
+  }
+}

--- a/packages/core/src/characters/japanese.ts
+++ b/packages/core/src/characters/japanese.ts
@@ -1,4 +1,5 @@
 import { Character } from "../character";
+import { CharacterSetFactory } from "../character-set-factory";
 
 export const HIRAGANA_CHARACTERS = [
   { label: "あ", inputPatterns: ["a"] },
@@ -236,32 +237,13 @@ export type KatakanaCharacter = (typeof KATAKANA_CHARACTERS)[number];
 export type JapaneseCharacter = (typeof JAPANESE_CHARACTERS)[number];
 
 export function fromJapaneseText(text: string): Character[] {
-  const characters: Character[] = [];
-  let i = 0;
-
-  while (i < text.length) {
-    let matched = false;
-
-    for (const characterData of [...JAPANESE_CHARACTERS].reverse()) {
-      if (
-        text.slice(i, i + characterData.label.length) === characterData.label
-      ) {
-        characters.push(
-          new Character({
-            label: characterData.label,
-            inputPatterns: [...characterData.inputPatterns],
-          }),
-        );
-        i += characterData.label.length;
-        matched = true;
-        break;
-      }
-    }
-
-    if (!matched) {
-      throw new Error(`Unsupported character: ${text[i]} at position ${i}`);
-    }
-  }
-
-  return characters;
+  const japaneseCharacters = JAPANESE_CHARACTERS.map(
+    (data) =>
+      new Character({
+        label: data.label,
+        inputPatterns: [...data.inputPatterns],
+      }),
+  );
+  const factory = new CharacterSetFactory(japaneseCharacters);
+  return factory.fromText(text).characters;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./character";
 export * from "./character-set";
+export * from "./character-set-factory";
 export * from "./sentence";
 export * from "./session";
 export { fromJapaneseText } from "./characters/japanese";


### PR DESCRIPTION
## Summary
- Add CharacterSetFactory class for easier CharacterSet creation from text
- Move text parsing logic from fromJapaneseText to CharacterSetFactory for better modularity
- Allow customizable character sets through constructor injection

## Test plan
- [x] Run all existing tests to ensure no regressions
- [x] Add comprehensive tests for CharacterSetFactory
- [x] Verify fromJapaneseText still works as expected
- [x] Test with various Japanese text inputs including complex characters

🤖 Generated with [Claude Code](https://claude.ai/code)