### PR TITLE
fix: use character preview for consistent typing display

### DIFF
--- a/apps/web/src/features/typing/components/session-input.tsx
+++ b/apps/web/src/features/typing/components/session-input.tsx
@@ -26,7 +26,6 @@ export function SessionInput({ sentences, onComplete }: SessionInputProps) {
     futureCharacters,
     futureCharacterPreviews,
     currentCharacterPreview,
-    suggestions,
   } = useSession({ sentences });
 
   const [error, setError] = useState(false);
@@ -63,7 +62,6 @@ export function SessionInput({ sentences, onComplete }: SessionInputProps) {
               futureCharacterPreviews={futureCharacterPreviews}
               currentInputs={inputs}
               currentCharacterPreview={currentCharacterPreview}
-              suggestions={suggestions}
               error={error}
             />
             <SentenceDisplay sentence={currentSentence} />

--- a/apps/web/src/features/typing/components/typing-display.tsx
+++ b/apps/web/src/features/typing/components/typing-display.tsx
@@ -7,7 +7,6 @@ type TypingDisplayProps = {
   futureCharacterPreviews: string[];
   currentInputs: string;
   currentCharacterPreview: string;
-  suggestions: string[];
   error: boolean;
 };
 
@@ -18,7 +17,6 @@ export function TypingDisplay({
   futureCharacterPreviews,
   currentInputs,
   currentCharacterPreview,
-  suggestions,
   error,
 }: TypingDisplayProps) {
   const remainingPreview = currentCharacterPreview.slice(currentInputs.length);

--- a/apps/web/src/features/typing/utils/use-session.ts
+++ b/apps/web/src/features/typing/utils/use-session.ts
@@ -42,11 +42,14 @@ export function useSession({ sentences }: UseSessionParams) {
               : character.getPreview();
           })
         : [],
-      currentCharacterPreview: currentCharacter && currentCharacterSet
-        ? currentCharacterSet.getCharacterPreview(
-            currentCharacterSet.characters.findIndex(c => c === currentCharacter)
-          )
-        : "",
+      currentCharacterPreview:
+        currentCharacter && currentCharacterSet
+          ? currentCharacterSet.getCharacterPreview(
+              currentCharacterSet.characters.findIndex(
+                (c) => c === currentCharacter,
+              ),
+            )
+          : "",
       suggestions: currentCharacterSet?.getCurrentCharacterSuggestions() || [],
     };
   });
@@ -99,11 +102,14 @@ export function useSession({ sentences }: UseSessionParams) {
                   : character.getPreview();
               })
             : [],
-          currentCharacterPreview: newCurrentCharacter && newCurrentCharacterSet
-            ? newCurrentCharacterSet.getCharacterPreview(
-                newCurrentCharacterSet.characters.findIndex(c => c === newCurrentCharacter)
-              )
-            : "",
+          currentCharacterPreview:
+            newCurrentCharacter && newCurrentCharacterSet
+              ? newCurrentCharacterSet.getCharacterPreview(
+                  newCurrentCharacterSet.characters.findIndex(
+                    (c) => c === newCurrentCharacter,
+                  ),
+                )
+              : "",
           suggestions:
             newCurrentCharacterSet?.getCurrentCharacterSuggestions() || [],
         });


### PR DESCRIPTION
## Summary
- Fix inconsistent character preview display when typing Japanese characters
- Switch from suggestions-based to preview-based display for current character

## Test plan
- [ ] Verify "ん" character shows consistent "nn" preview after typing "ko" + "n"
- [ ] Test other Japanese characters to ensure no regressions
- [ ] Confirm typing flow remains smooth and intuitive

🤖 Generated with [Claude Code](https://claude.ai/code)