### PR TITLE
refactor: simplify use-session.ts state management

### DIFF
--- a/apps/web/src/features/typing/components/typing-display.stories.tsx
+++ b/apps/web/src/features/typing/components/typing-display.stories.tsx
@@ -23,13 +23,19 @@ function createTypingDisplayProps(
       : character.getPreview();
   });
 
+  const currentCharacterPreview = currentCharacter
+    ? characterSet.getCharacterPreview(
+        characterSet.characters.findIndex((c) => c === currentCharacter),
+      )
+    : "";
+
   return {
     completedCharacters,
     currentCharacter,
     futureCharacters,
     futureCharacterPreviews,
     currentInputs,
-    suggestions: characterSet.getCurrentCharacterSuggestions(),
+    currentCharacterPreview,
     error,
   };
 }
@@ -63,8 +69,8 @@ const meta: Meta<typeof TypingDisplay> = {
     currentInputs: {
       description: "Current user inputs for the current character",
     },
-    suggestions: {
-      description: "Input suggestions for the current character",
+    currentCharacterPreview: {
+      description: "Preview string for the current character",
     },
     error: {
       description: "Whether there is an error in typing",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Extract sessionSnapshot construction logic to dedicated `createSessionSnapshot` function 
- Remove 42 lines of duplicate code by consolidating repeated sessionSnapshot building logic
- Replace `suggestions` property with existing `currentCharacterPreview` for better consistency
- Improve type safety by replacing `any` types with proper `Character` types

## Test plan
- [x] All existing tests pass
- [x] TypeScript compilation succeeds  
- [x] ESLint checks pass
- [x] Storybook stories updated to use currentCharacterPreview instead of suggestions

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)