### PR TITLE
feat: require double-n for ん at end of sentences

### DIFF
--- a/packages/core/src/character-set-input.test.ts
+++ b/packages/core/src/character-set-input.test.ts
@@ -26,7 +26,18 @@ describe("CharacterSet input methods", () => {
       // Complete "あ"
       characterSet.inputCurrentCharacter("a");
 
-      // Check preview for "ん" - should be "nn" when next is "ば" (not n-starting)
+      // Check preview for "ん" - should be "n" when next is "ば" (not n-starting and not at end)
+      expect(characterSet.getCharacterPreview(1)).toBe("n");
+    });
+
+    it("should return nn for ん at the end of sentence", () => {
+      const characters = fromJapaneseText("あん");
+      const characterSet = new CharacterSet(characters);
+
+      // Complete "あ"
+      characterSet.inputCurrentCharacter("a");
+
+      // Check preview for "ん" - should be "nn" when at the end
       expect(characterSet.getCharacterPreview(1)).toBe("nn");
     });
   });

--- a/packages/core/src/characters/japanese.ts
+++ b/packages/core/src/characters/japanese.ts
@@ -4,11 +4,15 @@ import { CharacterSetFactory } from "../character-set-factory";
 const createNInputPatternResolver = (): InputPatternResolver => {
   return (context) => {
     // 次の文字が「な行」の場合は "nn" のみ
-    if (context.next && context.next.getPreview().startsWith("n")) {
+    if (context.next && context.next.getPreview(context).startsWith("n")) {
+      return ["nn"];
+    }
+    // 文章の最後の場合は "nn" のみ
+    if (!context.next) {
       return ["nn"];
     }
     // それ以外は両方許可
-    return ["nn", "n"];
+    return ["n", "nn"];
   };
 };
 

--- a/packages/core/src/contextual-input-patterns.test.ts
+++ b/packages/core/src/contextual-input-patterns.test.ts
@@ -146,9 +146,14 @@ describe("Contextual Input Patterns", () => {
       // Should only allow "nn" when next is "な"
       expect(nnChar.getInputPatterns(context)).toEqual(["nn"]);
 
-      // Context where next character is not "な"
-      const contextNoN = { prev: characters[0], next: null };
-      expect(nnChar.getInputPatterns(contextNoN)).toEqual(["nn", "n"]);
+      // Context where next character is not "な" but not at end
+      const baChar = characters[3]; // "か"
+      const contextNoN = { prev: characters[0], next: baChar };
+      expect(nnChar.getInputPatterns(contextNoN)).toEqual(["n", "nn"]);
+
+      // Context where character is at the end of sentence
+      const contextEnd = { prev: characters[0], next: null };
+      expect(nnChar.getInputPatterns(contextEnd)).toEqual(["nn"]);
     });
   });
 
@@ -185,6 +190,28 @@ describe("Contextual Input Patterns", () => {
       // Since next character is "ば" (starts with "b"), single "n" should be allowed
       expect(nnChar.input("n", context)).toBe(true);
       expect(nnChar.isCompleted(context)).toBe(true); // Should be completed with single "n"
+    });
+
+    it("should require nn when ん is at the end of sentence", () => {
+      const characters = fromJapaneseText("まん");
+      const characterSet = new CharacterSet(characters);
+
+      const nnChar = characterSet.characters[1]; // "ん"
+      const context = {
+        prev: characterSet.characters[0],
+        next: null, // End of sentence
+      };
+
+      // Should only allow "nn" when at the end of sentence
+      expect(nnChar.getInputPatterns(context)).toEqual(["nn"]);
+
+      // Single "n" should not complete when at the end
+      expect(nnChar.input("n", context)).toBe(true);
+      expect(nnChar.isCompleted(context)).toBe(false);
+
+      // Double "nn" should complete
+      expect(nnChar.input("n", context)).toBe(true);
+      expect(nnChar.isCompleted(context)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Improve `createNInputPatternResolver` to require "nn" for ん at the end of sentences
- Add consistent typing behavior for sentence-ending ん characters
- Update test cases to cover new end-of-sentence behavior

## Test plan
- [x] All existing tests pass
- [x] New test cases added for end-of-sentence ん behavior  
- [x] TypeScript compilation succeeds
- [x] ESLint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)