### PR TITLE
fix: prevent typing progress counter from exceeding total sentences

### DIFF
--- a/apps/web/src/features/typing/components/session-input.tsx
+++ b/apps/web/src/features/typing/components/session-input.tsx
@@ -43,7 +43,8 @@ export function SessionInput({ sentences, onComplete }: SessionInputProps) {
       <div className="mb-6">
         <div className="flex justify-between items-center mb-2">
           <span className="text-sm text-gray-600">
-            文章 {currentSentenceIndex + 1} / {allSentences.length}
+            文章 {Math.min(currentSentenceIndex + 1, allSentences.length)} /{" "}
+            {allSentences.length}
           </span>
           <span className="text-sm text-gray-600">
             {Math.round(progress)}% 完了


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- タイピング完了時に進捗表示が「文章 4/3」のように分母を超えてしまう問題を修正

## Test plan
- [ ] タイピングで最後の文章を完了した時に進捗表示が分母を超えないことを確認
- [ ] 途中の文章でも正しく進捗が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)