### PR TITLE
feat: add robots metadata to prevent search engine indexing

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -46,6 +46,14 @@ export const metadata: Metadata = {
     title: "だけんちゅ - 日本語タイピング練習",
     description: "日本語タイピング練習のためのWebアプリケーション",
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Add robots configuration to layout.tsx metadata to prevent search engine indexing
- Configure both general robots settings and specific googleBot settings to block crawling

## Test plan
- [ ] Verify that the metadata is correctly applied in the HTML head
- [ ] Check that robots meta tags are present in the page source
- [ ] Confirm no TypeScript errors in the updated layout file

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)