### PR TITLE
feat: add application header with title and subtitle for improved branding

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
+import { Header } from "../ui/components";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -66,7 +67,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Providers>{children}</Providers>
+        <Providers>
+          <Header title="だけんちゅ" subtitle="日本語タイピング練習" />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
   ];
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
+    <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center p-4">
       <SessionInput
         sentences={sampleSentences}
         onComplete={() => console.log("セッション完了！")}

--- a/apps/web/src/ui/components/header.tsx
+++ b/apps/web/src/ui/components/header.tsx
@@ -1,0 +1,21 @@
+type HeaderProps = {
+  title: string;
+  subtitle?: string;
+};
+
+export function Header({ title, subtitle }: HeaderProps) {
+  return (
+    <header className="border-b border-gray-200 bg-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          <div className="flex items-center">
+            <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
+            {subtitle && (
+              <span className="ml-3 text-sm text-gray-500">{subtitle}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/ui/components/index.ts
+++ b/apps/web/src/ui/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./button";
 export * from "./progress";
+export * from "./header";


### PR DESCRIPTION
## Summary

- アプリケーションタイトル「だけんちゅ」を表示するヘッダーコンポーネントを追加
- ブランディングとユーザビリティの向上

## Test plan

- [ ] ヘッダーが正しく表示されることを確認
- [ ] タイトルとサブタイトルが適切に表示されることを確認
- [ ] レスポンシブデザインが正常に動作することを確認
- [ ] タイピング練習機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)