### PR TITLE
refactor: replace fromJapaneseText with createCharacterSetFactory

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,20 +1,27 @@
 "use client";
 
-import { Sentence, fromJapaneseText, CharacterSet } from "@dakenjin/core";
+import {
+  Sentence,
+  createCharacterSetFactory,
+  CharacterSet,
+} from "@dakenjin/core";
 import { SessionInput } from "../features/typing/components/session-input";
 
 export default function Home() {
+  const factory = createCharacterSetFactory();
   const sampleSentences = [
     new Sentence(
-      new CharacterSet(fromJapaneseText("こんにちはせかい")),
+      new CharacterSet(factory.fromText("こんにちはせかい").characters),
       "こんにちは世界",
     ),
     new Sentence(
-      new CharacterSet(fromJapaneseText("プログラミングはたのしい")),
+      new CharacterSet(factory.fromText("プログラミングはたのしい").characters),
       "プログラミングは楽しい",
     ),
     new Sentence(
-      new CharacterSet(fromJapaneseText("タイピングれんしゅうをがんばろう")),
+      new CharacterSet(
+        factory.fromText("タイピングれんしゅうをがんばろう").characters,
+      ),
       "タイピング練習を頑張ろう",
     ),
   ];

--- a/apps/web/src/features/typing/components/sentence-display.stories.tsx
+++ b/apps/web/src/features/typing/components/sentence-display.stories.tsx
@@ -3,7 +3,7 @@ import {
   Sentence,
   CharacterSet,
   Character,
-  fromJapaneseText,
+  createCharacterSetFactory,
 } from "@dakenjin/core";
 import { SentenceDisplay } from "./sentence-display";
 
@@ -45,10 +45,12 @@ export const SingleCharacter: Story = {
   },
 };
 
+const factory = createCharacterSetFactory();
+
 export const ShortSentence: Story = {
   args: {
     sentence: new Sentence(
-      new CharacterSet(fromJapaneseText("こんにちは")),
+      new CharacterSet(factory.fromText("こんにちは").characters),
       "こんにちは",
     ),
   },
@@ -57,7 +59,9 @@ export const ShortSentence: Story = {
 export const LongSentence: Story = {
   args: {
     sentence: new Sentence(
-      new CharacterSet(fromJapaneseText("わたしはにほんごをよみます")),
+      new CharacterSet(
+        factory.fromText("わたしはにほんごをよみます").characters,
+      ),
       "わたしはにほんごをよみます",
     ),
   },
@@ -66,7 +70,7 @@ export const LongSentence: Story = {
 export const MixedCharacters: Story = {
   args: {
     sentence: new Sentence(
-      new CharacterSet(fromJapaneseText("わたしのなまえ")),
+      new CharacterSet(factory.fromText("わたしのなまえ").characters),
       "わたしのなまえ",
     ),
   },

--- a/apps/web/src/features/typing/components/session-input.stories.tsx
+++ b/apps/web/src/features/typing/components/session-input.stories.tsx
@@ -1,5 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
-import { Sentence, fromJapaneseText, CharacterSet } from "@dakenjin/core";
+import {
+  Sentence,
+  createCharacterSetFactory,
+  CharacterSet,
+} from "@dakenjin/core";
 import { SessionInput } from "./session-input";
 
 const meta: Meta<typeof SessionInput> = {
@@ -28,11 +32,13 @@ const meta: Meta<typeof SessionInput> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const factory = createCharacterSetFactory();
+
 export const SingleSentence: Story = {
   args: {
     sentences: [
       new Sentence(
-        new CharacterSet(fromJapaneseText("こんにちは")),
+        new CharacterSet(factory.fromText("こんにちは").characters),
         "こんにちは",
       ),
     ],
@@ -44,15 +50,15 @@ export const MultipleSentences: Story = {
   args: {
     sentences: [
       new Sentence(
-        new CharacterSet(fromJapaneseText("こんにちは")),
+        new CharacterSet(factory.fromText("こんにちは").characters),
         "こんにちは",
       ),
       new Sentence(
-        new CharacterSet(fromJapaneseText("ありがとう")),
+        new CharacterSet(factory.fromText("ありがとう").characters),
         "ありがとう",
       ),
       new Sentence(
-        new CharacterSet(fromJapaneseText("さようなら")),
+        new CharacterSet(factory.fromText("さようなら").characters),
         "さようなら",
       ),
     ],
@@ -64,7 +70,9 @@ export const LongSentence: Story = {
   args: {
     sentences: [
       new Sentence(
-        new CharacterSet(fromJapaneseText("わたしはにほんごをよみます")),
+        new CharacterSet(
+          factory.fromText("わたしはにほんごをよみます").characters,
+        ),
         "わたしはにほんごをよみます",
       ),
     ],

--- a/packages/core/src/character-set-factory.ts
+++ b/packages/core/src/character-set-factory.ts
@@ -1,5 +1,17 @@
 import { Character } from "./character";
 import { CharacterSet } from "./character-set";
+import { JAPANESE_CHARACTERS } from "./characters/japanese";
+
+export function createCharacterSetFactory(): CharacterSetFactory {
+  const japaneseCharacters = JAPANESE_CHARACTERS.map((data) => {
+    return new Character({
+      label: data.label,
+      inputPatterns: [...data.inputPatterns],
+      inputPatternResolver: (data as any).inputPatternResolver,
+    });
+  });
+  return new CharacterSetFactory(japaneseCharacters);
+}
 
 export class CharacterSetFactory {
   private _characters: Character[];

--- a/packages/core/src/character-set-input.test.ts
+++ b/packages/core/src/character-set-input.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { CharacterSet } from "./character-set";
-import { fromJapaneseText } from "./characters/japanese";
+import { createCharacterSetFactory } from "./character-set-factory";
 
 describe("CharacterSet input methods", () => {
+  const factory = createCharacterSetFactory();
+
   describe("getCharacterPreview", () => {
     it("should return context-aware preview for characters", () => {
-      const characters = fromJapaneseText("こんにちは");
+      const characters = factory.fromText("こんにちは").characters;
       const characterSet = new CharacterSet(characters);
 
       // Complete "こ"
@@ -20,7 +22,7 @@ describe("CharacterSet input methods", () => {
     });
 
     it("should work with different contexts", () => {
-      const characters = fromJapaneseText("あんば");
+      const characters = factory.fromText("あんば").characters;
       const characterSet = new CharacterSet(characters);
 
       // Complete "あ"
@@ -31,7 +33,7 @@ describe("CharacterSet input methods", () => {
     });
 
     it("should return nn for ん at the end of sentence", () => {
-      const characters = fromJapaneseText("あん");
+      const characters = factory.fromText("あん").characters;
       const characterSet = new CharacterSet(characters);
 
       // Complete "あ"
@@ -44,7 +46,7 @@ describe("CharacterSet input methods", () => {
 
   describe("inputCurrentCharacter", () => {
     it("should input to current character with context", () => {
-      const characters = fromJapaneseText("こんにちは");
+      const characters = factory.fromText("こんにちは").characters;
       const characterSet = new CharacterSet(characters);
 
       // こ - ko
@@ -70,7 +72,7 @@ describe("CharacterSet input methods", () => {
     });
 
     it("should return correct suggestions with context", () => {
-      const characters = fromJapaneseText("こんにちは");
+      const characters = factory.fromText("こんにちは").characters;
       const characterSet = new CharacterSet(characters);
 
       // Complete "こ"
@@ -83,7 +85,7 @@ describe("CharacterSet input methods", () => {
     });
 
     it("should work with different contexts", () => {
-      const characters = fromJapaneseText("あんば");
+      const characters = factory.fromText("あんば").characters;
       const characterSet = new CharacterSet(characters);
 
       // Complete "あ"

--- a/packages/core/src/characters/japanese.test.ts
+++ b/packages/core/src/characters/japanese.test.ts
@@ -1,23 +1,24 @@
 import { describe, test, expect } from "vitest";
-import { fromJapaneseText } from "./japanese";
+import { createCharacterSetFactory } from "../character-set-factory";
 
 describe("fromJapaneseText", () => {
   test("単一のひらがなを変換する", () => {
-    const result = fromJapaneseText("あ");
+    const result = createCharacterSetFactory().fromText("あ").characters;
     expect(result).toHaveLength(1);
     expect(result[0].label).toBe("あ");
     expect(result[0].inputPatterns).toEqual(["a"]);
   });
 
   test("単一のカタカナを変換する", () => {
-    const result = fromJapaneseText("ア");
+    const result = createCharacterSetFactory().fromText("ア").characters;
     expect(result).toHaveLength(1);
     expect(result[0].label).toBe("ア");
     expect(result[0].inputPatterns).toEqual(["a"]);
   });
 
   test("複数文字のひらがなを変換する", () => {
-    const result = fromJapaneseText("こんにちは");
+    const result =
+      createCharacterSetFactory().fromText("こんにちは").characters;
     expect(result).toHaveLength(5);
     expect(result[0].label).toBe("こ");
     expect(result[1].label).toBe("ん");
@@ -27,14 +28,14 @@ describe("fromJapaneseText", () => {
   });
 
   test("拗音（2文字組み合わせ）を正しく変換する", () => {
-    const result = fromJapaneseText("しゃ");
+    const result = createCharacterSetFactory().fromText("しゃ").characters;
     expect(result).toHaveLength(1);
     expect(result[0].label).toBe("しゃ");
     expect(result[0].inputPatterns).toEqual(["sha", "sya"]);
   });
 
   test("拗音を含む文字列を変換する", () => {
-    const result = fromJapaneseText("きょう");
+    const result = createCharacterSetFactory().fromText("きょう").characters;
     expect(result).toHaveLength(2);
     expect(result[0].label).toBe("きょ");
     expect(result[0].inputPatterns).toEqual(["kyo"]);
@@ -43,7 +44,8 @@ describe("fromJapaneseText", () => {
   });
 
   test("ひらがなとカタカナが混在する文字列を変換する", () => {
-    const result = fromJapaneseText("ひらがなカタカナ");
+    const result =
+      createCharacterSetFactory().fromText("ひらがなカタカナ").characters;
     expect(result).toHaveLength(8);
     expect(result[0].label).toBe("ひ");
     expect(result[1].label).toBe("ら");
@@ -56,38 +58,39 @@ describe("fromJapaneseText", () => {
   });
 
   test("複数の入力パターンを持つ文字を変換する", () => {
-    const result = fromJapaneseText("し");
+    const result = createCharacterSetFactory().fromText("し").characters;
     expect(result).toHaveLength(1);
     expect(result[0].label).toBe("し");
     expect(result[0].inputPatterns).toEqual(["shi", "si"]);
   });
 
   test("小さいつを変換する", () => {
-    const result = fromJapaneseText("っ");
+    const result = createCharacterSetFactory().fromText("っ").characters;
     expect(result).toHaveLength(1);
     expect(result[0].label).toBe("っ");
     expect(result[0].inputPatterns).toEqual(["xtu", "ltu", "xtsu", "ltsu"]);
   });
 
   test("サポートされていない文字でエラーを投げる", () => {
-    expect(() => fromJapaneseText("hello")).toThrow(
+    expect(() => createCharacterSetFactory().fromText("hello")).toThrow(
       "Unsupported character: h at position 0",
     );
-    expect(() => fromJapaneseText("あa")).toThrow(
+    expect(() => createCharacterSetFactory().fromText("あa")).toThrow(
       "Unsupported character: a at position 1",
     );
-    expect(() => fromJapaneseText("123")).toThrow(
+    expect(() => createCharacterSetFactory().fromText("123")).toThrow(
       "Unsupported character: 1 at position 0",
     );
   });
 
   test("空文字列を変換する", () => {
-    const result = fromJapaneseText("");
+    const result = createCharacterSetFactory().fromText("").characters;
     expect(result).toHaveLength(0);
   });
 
   test("長い拗音を含む複雑な文字列を変換する", () => {
-    const result = fromJapaneseText("しゃべりゅう");
+    const result =
+      createCharacterSetFactory().fromText("しゃべりゅう").characters;
     expect(result).toHaveLength(4);
     expect(result[0].label).toBe("しゃ");
     expect(result[1].label).toBe("べ");

--- a/packages/core/src/characters/japanese.ts
+++ b/packages/core/src/characters/japanese.ts
@@ -1,5 +1,4 @@
-import { Character, InputPatternResolver } from "../character";
-import { CharacterSetFactory } from "../character-set-factory";
+import { InputPatternResolver } from "../character";
 
 const createNInputPatternResolver = (): InputPatternResolver => {
   return (context) => {
@@ -258,15 +257,3 @@ export const JAPANESE_CHARACTERS = [
 export type HiraganaCharacter = (typeof HIRAGANA_CHARACTERS)[number];
 export type KatakanaCharacter = (typeof KATAKANA_CHARACTERS)[number];
 export type JapaneseCharacter = (typeof JAPANESE_CHARACTERS)[number];
-
-export function fromJapaneseText(text: string): Character[] {
-  const japaneseCharacters = JAPANESE_CHARACTERS.map((data) => {
-    return new Character({
-      label: data.label,
-      inputPatterns: [...data.inputPatterns],
-      inputPatternResolver: (data as any).inputPatternResolver,
-    });
-  });
-  const factory = new CharacterSetFactory(japaneseCharacters);
-  return factory.fromText(text).characters;
-}

--- a/packages/core/src/contextual-input-patterns.test.ts
+++ b/packages/core/src/contextual-input-patterns.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Character, InputPatternResolver } from "./character";
 import { CharacterSet } from "./character-set";
-import { fromJapaneseText } from "./characters/japanese";
+import { createCharacterSetFactory } from "./character-set-factory";
 
 describe("Contextual Input Patterns", () => {
   describe("Character class", () => {
@@ -132,8 +132,10 @@ describe("Contextual Input Patterns", () => {
   });
 
   describe("fromJapaneseText with contextual patterns", () => {
+    const factory = createCharacterSetFactory();
+
     it("should create ん character with context-aware input patterns", () => {
-      const characters = fromJapaneseText("まんなか");
+      const characters = factory.fromText("まんなか").characters;
       const nnChar = characters[1]; // "ん"
       const naChar = characters[2]; // "な"
 
@@ -158,8 +160,10 @@ describe("Contextual Input Patterns", () => {
   });
 
   describe("CharacterSet with contextual patterns", () => {
+    const factory = createCharacterSetFactory();
+
     it("should provide correct context to characters", () => {
-      const characters = fromJapaneseText("まんなか");
+      const characters = factory.fromText("まんなか").characters;
       const characterSet = new CharacterSet(characters);
 
       // Get the "ん" character
@@ -178,7 +182,7 @@ describe("Contextual Input Patterns", () => {
     });
 
     it("should handle completion correctly with context", () => {
-      const characters = fromJapaneseText("あんば");
+      const characters = factory.fromText("あんば").characters;
       const characterSet = new CharacterSet(characters);
 
       const nnChar = characterSet.characters[1]; // "ん"
@@ -193,7 +197,7 @@ describe("Contextual Input Patterns", () => {
     });
 
     it("should require nn when ん is at the end of sentence", () => {
-      const characters = fromJapaneseText("まん");
+      const characters = factory.fromText("まん").characters;
       const characterSet = new CharacterSet(characters);
 
       const nnChar = characterSet.characters[1]; // "ん"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,4 +3,4 @@ export * from "./character-set";
 export * from "./character-set-factory";
 export * from "./sentence";
 export * from "./session";
-export { fromJapaneseText } from "./characters/japanese";
+export { createCharacterSetFactory } from "./character-set-factory";

--- a/packages/core/src/tests/session.e2e.test.ts
+++ b/packages/core/src/tests/session.e2e.test.ts
@@ -1,21 +1,31 @@
 import { describe, it, expect } from "vitest";
 import { Session, Sentence, CharacterSet } from "../index";
-import { fromJapaneseText } from "../characters/japanese";
+import { createCharacterSetFactory } from "../character-set-factory";
 
 describe("Session E2E Tests - Complete Application Flow", () => {
   it("should complete all three sample sentences from page.tsx", () => {
     // Create the exact same sentences as defined in page.tsx
     const sampleSentences = [
       new Sentence(
-        new CharacterSet(fromJapaneseText("こんにちはせかい")),
+        new CharacterSet(
+          createCharacterSetFactory().fromText("こんにちはせかい").characters,
+        ),
         "こんにちは世界",
       ),
       new Sentence(
-        new CharacterSet(fromJapaneseText("プログラミングはたのしい")),
+        new CharacterSet(
+          createCharacterSetFactory().fromText(
+            "プログラミングはたのしい",
+          ).characters,
+        ),
         "プログラミングは楽しい",
       ),
       new Sentence(
-        new CharacterSet(fromJapaneseText("タイピングれんしゅうをがんばろう")),
+        new CharacterSet(
+          createCharacterSetFactory().fromText(
+            "タイピングれんしゅうをがんばろう",
+          ).characters,
+        ),
         "タイピング練習を頑張ろう",
       ),
     ];
@@ -195,11 +205,15 @@ describe("Session E2E Tests - Complete Application Flow", () => {
   it("should handle errors and recovery during the complete session", () => {
     const sampleSentences = [
       new Sentence(
-        new CharacterSet(fromJapaneseText("こんにちは")),
+        new CharacterSet(
+          createCharacterSetFactory().fromText("こんにちは").characters,
+        ),
         "こんにちは",
       ),
       new Sentence(
-        new CharacterSet(fromJapaneseText("ありがとう")),
+        new CharacterSet(
+          createCharacterSetFactory().fromText("ありがとう").characters,
+        ),
         "ありがとう",
       ),
     ];


### PR DESCRIPTION
## Summary
- Add `createCharacterSetFactory` function that returns a CharacterSetFactory instance with JAPANESE_CHARACTERS pre-configured
- Remove deprecated `fromJapaneseText` function from japanese.ts  
- Update all imports and usage throughout the codebase to use the new factory approach
- Optimize factory instance reuse to improve performance by avoiding repeated Character instance creation

## Test plan
- [x] All existing tests pass (90 tests)
- [x] TypeScript compilation succeeds
- [x] ESLint passes
- [x] Prettier formatting applied
- [x] Manual verification that Web app still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)