### PR TITLE
feat: add SessionAnalyzer for typing statistics calculation

### DIFF
--- a/apps/web/src/features/typing/components/session-input.tsx
+++ b/apps/web/src/features/typing/components/session-input.tsx
@@ -7,6 +7,7 @@ import { useSession } from "../utils/use-session";
 import { TypingDisplay } from "./typing-display";
 import { SentenceDisplay } from "./sentence-display";
 import { TypingInput } from "./typing-input";
+import { TypingStatsDisplay } from "./typing-stats";
 
 type SessionInputProps = {
   sentences: Sentence[];
@@ -15,6 +16,7 @@ type SessionInputProps = {
 
 export function SessionInput({ sentences, onComplete }: SessionInputProps) {
   const {
+    session,
     currentSentence,
     currentCharacter,
     completedSentences,
@@ -79,14 +81,19 @@ export function SessionInput({ sentences, onComplete }: SessionInputProps) {
       />
 
       {isCompleted && (
-        <div className="text-center bg-gradient-to-r from-primary/10 to-accent/10 rounded-3xl p-8 shadow-lg border border-primary/20">
+        <div className="text-center bg-gradient-to-r from-primary/10 to-accent/10 rounded-3xl p-8 shadow-lg border border-primary/20 space-y-6">
           <div className="text-6xl mb-4">🎉</div>
           <h2 className="text-3xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent mb-4">
             セッション完了！
           </h2>
-          <p className="text-muted-foreground text-lg">
+          <p className="text-muted-foreground text-lg mb-6">
             全ての文章の入力が完了しました。お疲れ様でした！
           </p>
+
+          <div className="max-w-2xl mx-auto">
+            <h3 className="text-xl font-semibold text-foreground mb-4">結果</h3>
+            <TypingStatsDisplay session={session} />
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/features/typing/components/typing-stats.stories.tsx
+++ b/apps/web/src/features/typing/components/typing-stats.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { TypingStatsDisplay } from "./typing-stats";
+import { Session, Sentence, Character, CharacterSet } from "@dakenjin/core";
+
+const meta: Meta<typeof TypingStatsDisplay> = {
+  title: "Features/Typing/TypingStatsDisplay",
+  component: TypingStatsDisplay,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Initial: Story = {
+  args: {
+    session: createSession(),
+  },
+};
+
+export const Completed: Story = {
+  args: {
+    session: createCompletedSession(),
+  },
+};
+
+export const WithErrors: Story = {
+  args: {
+    session: createSessionWithErrors(),
+  },
+};
+
+function createSession(): Session {
+  const characters = [
+    new Character({ label: "あ", inputPatterns: ["a"] }),
+    new Character({ label: "い", inputPatterns: ["i"] }),
+    new Character({ label: "う", inputPatterns: ["u"] }),
+  ];
+  const sentence = new Sentence(new CharacterSet(characters), "あいう");
+  return new Session([sentence]);
+}
+
+function createCompletedSession(): Session {
+  const session = createSession();
+
+  const currentSentence = session.currentSentence;
+  const sentence = currentSentence!;
+  void sentence.currentCharacter;
+  sentence.inputCurrentCharacter("a");
+  sentence.inputCurrentCharacter("i");
+  sentence.inputCurrentCharacter("u");
+
+  session.isCompleted();
+
+  return session;
+}
+
+function createSessionWithErrors(): Session {
+  const session = createSession();
+
+  const currentSentence = session.currentSentence;
+  const sentence = currentSentence!;
+  void sentence.currentCharacter;
+
+  const character = sentence.currentCharacter!;
+  character.inputLog.recordKeyInput("x", false);
+  character.inputLog.recordKeyInput("y", false);
+  sentence.inputCurrentCharacter("a");
+
+  return session;
+}

--- a/apps/web/src/features/typing/components/typing-stats.tsx
+++ b/apps/web/src/features/typing/components/typing-stats.tsx
@@ -1,0 +1,60 @@
+import type { Session } from "@dakenjin/core";
+import { calculateTypingStats, formatTime } from "../utils/typing-stats";
+
+type TypingStatsProps = {
+  session: Session;
+};
+
+export function TypingStatsDisplay({ session }: TypingStatsProps) {
+  const stats = calculateTypingStats(session);
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 bg-gray-50 rounded-lg border">
+      <StatCard
+        label="経過時間"
+        value={formatTime(stats.elapsedTime)}
+        className="text-blue-600"
+      />
+      <StatCard
+        label="打鍵数"
+        value={stats.totalKeystrokes.toString()}
+        subtitle={`成功: ${stats.successfulKeystrokes} / 失敗: ${stats.failedKeystrokes}`}
+        className="text-green-600"
+      />
+      <StatCard
+        label="正確性"
+        value={`${stats.accuracy}%`}
+        className={
+          stats.accuracy >= 95
+            ? "text-green-600"
+            : stats.accuracy >= 85
+              ? "text-yellow-600"
+              : "text-red-600"
+        }
+      />
+      <StatCard
+        label="入力速度"
+        value={`${stats.kps} KPS`}
+        subtitle={`${stats.cpm} CPM`}
+        className="text-purple-600"
+      />
+    </div>
+  );
+}
+
+type StatCardProps = {
+  label: string;
+  value: string;
+  subtitle?: string;
+  className?: string;
+};
+
+function StatCard({ label, value, subtitle, className }: StatCardProps) {
+  return (
+    <div className="text-center">
+      <div className="text-sm text-gray-600 mb-1">{label}</div>
+      <div className={`text-2xl font-bold ${className || ""}`}>{value}</div>
+      {subtitle && <div className="text-xs text-gray-500 mt-1">{subtitle}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/features/typing/utils/typing-stats.test.ts
+++ b/apps/web/src/features/typing/utils/typing-stats.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { calculateTypingStats, formatTime } from "./typing-stats";
+import { Session, Sentence, Character, CharacterSet } from "@dakenjin/core";
+
+describe("calculateTypingStats", () => {
+  let session: Session;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+
+    const characters = [
+      new Character({ label: "あ", inputPatterns: ["a"] }),
+      new Character({ label: "い", inputPatterns: ["i"] }),
+      new Character({ label: "う", inputPatterns: ["u"] }),
+    ];
+    const sentence = new Sentence(new CharacterSet(characters), "あいう");
+    session = new Session([sentence]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return initial stats for new session", () => {
+    const stats = calculateTypingStats(session);
+
+    expect(stats.elapsedTime).toBe(0);
+    expect(stats.totalKeystrokes).toBe(0);
+    expect(stats.successfulKeystrokes).toBe(0);
+    expect(stats.failedKeystrokes).toBe(0);
+    expect(stats.accuracy).toBe(0);
+    expect(stats.kps).toBe(0);
+    expect(stats.cpm).toBe(0);
+    expect(stats.isActive).toBe(false);
+  });
+
+  it("should calculate stats for active session", () => {
+    void session.currentSentence;
+
+    vi.advanceTimersByTime(10000);
+
+    const stats = calculateTypingStats(session);
+
+    expect(stats.elapsedTime).toBe(10);
+    expect(stats.isActive).toBe(true);
+  });
+
+  it("should calculate keystroke stats correctly", () => {
+    const currentSentence = session.currentSentence;
+    const sentence = currentSentence!;
+    void sentence.currentCharacter;
+
+    const character = sentence.currentCharacter!;
+    character.inputLog.recordKeyInput("x", false);
+    character.inputLog.recordKeyInput("y", false);
+    sentence.inputCurrentCharacter("a");
+
+    const stats = calculateTypingStats(session);
+
+    expect(stats.totalKeystrokes).toBe(3);
+    expect(stats.successfulKeystrokes).toBe(1);
+    expect(stats.failedKeystrokes).toBe(2);
+    expect(stats.accuracy).toBe(33.3);
+  });
+
+  it("should calculate KPS and CPM correctly", () => {
+    const currentSentence = session.currentSentence;
+    const sentence = currentSentence!;
+    void sentence.currentCharacter;
+
+    for (let i = 0; i < 5; i++) {
+      const char = sentence.currentCharacter;
+      if (char) {
+        char.inputLog.recordKeyInput("a", true);
+      }
+    }
+
+    vi.advanceTimersByTime(10000);
+
+    const stats = calculateTypingStats(session);
+
+    expect(stats.kps).toBe(0.5);
+    expect(stats.cpm).toBe(30);
+  });
+
+  it("should handle completed session", () => {
+    const currentSentence = session.currentSentence;
+    const sentence = currentSentence!;
+    void sentence.currentCharacter;
+    sentence.inputCurrentCharacter("a");
+    sentence.inputCurrentCharacter("i");
+    sentence.inputCurrentCharacter("u");
+
+    session.isCompleted();
+
+    const stats = calculateTypingStats(session);
+
+    expect(stats.isActive).toBe(false);
+    expect(stats.totalKeystrokes).toBe(3);
+    expect(stats.successfulKeystrokes).toBe(3);
+    expect(stats.accuracy).toBe(100);
+  });
+});
+
+describe("formatTime", () => {
+  it("should format seconds correctly", () => {
+    expect(formatTime(5.5)).toBe("5.5s");
+    expect(formatTime(30)).toBe("30.0s");
+    expect(formatTime(59.9)).toBe("59.9s");
+  });
+
+  it("should format minutes and seconds correctly", () => {
+    expect(formatTime(60)).toBe("1:00.0");
+    expect(formatTime(65.5)).toBe("1:05.5");
+    expect(formatTime(125.3)).toBe("2:05.3");
+  });
+
+  it("should pad seconds correctly", () => {
+    expect(formatTime(61)).toBe("1:01.0");
+    expect(formatTime(69.5)).toBe("1:09.5");
+  });
+});

--- a/apps/web/src/features/typing/utils/typing-stats.ts
+++ b/apps/web/src/features/typing/utils/typing-stats.ts
@@ -1,0 +1,38 @@
+import { SessionAnalyzer } from "@dakenjin/core";
+
+export type TypingStats = {
+  elapsedTime: number;
+  totalKeystrokes: number;
+  successfulKeystrokes: number;
+  failedKeystrokes: number;
+  accuracy: number;
+  kps: number;
+  cpm: number;
+  isActive: boolean;
+};
+
+export function calculateTypingStats(
+  session: ConstructorParameters<typeof SessionAnalyzer>[0],
+): TypingStats {
+  const analyzer = new SessionAnalyzer(session);
+  return {
+    elapsedTime: analyzer.getDuration(),
+    totalKeystrokes: analyzer.getTotalKeystrokes(),
+    successfulKeystrokes: analyzer.getSuccessfulKeystrokes(),
+    failedKeystrokes: analyzer.getFailedKeystrokes(),
+    accuracy: analyzer.calcAccuracy(),
+    kps: analyzer.calcKps(),
+    cpm: analyzer.calcCpm(),
+    isActive: analyzer.isActive(),
+  };
+}
+
+export function formatTime(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}:${remainingSeconds.toFixed(1).padStart(4, "0")}`;
+}

--- a/apps/web/src/features/typing/utils/use-session.ts
+++ b/apps/web/src/features/typing/utils/use-session.ts
@@ -88,6 +88,7 @@ export function useSession({ sentences }: UseSessionParams) {
   );
 
   return {
+    session,
     currentSentence: sessionSnapshot.currentSentence,
     currentCharacter: sessionSnapshot.currentCharacter,
     completedSentences: sessionSnapshot.completedSentences,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,4 +6,5 @@ export * from "./sentence";
 export * from "./sentence-input-log";
 export * from "./session";
 export * from "./session-input-log";
+export * from "./session-analyzer";
 export { createCharacterSetFactory } from "./character-set-factory";

--- a/packages/core/src/session-analyzer.test.ts
+++ b/packages/core/src/session-analyzer.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { SessionAnalyzer } from "./session-analyzer";
+import { Session, Sentence, Character, CharacterSet } from "./index";
+
+describe("SessionAnalyzer", () => {
+  let session: Session;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+
+    const characters = [
+      new Character({ label: "あ", inputPatterns: ["a"] }),
+      new Character({ label: "い", inputPatterns: ["i"] }),
+      new Character({ label: "う", inputPatterns: ["u"] }),
+    ];
+    const sentence = new Sentence(new CharacterSet(characters), "あいう");
+    session = new Session([sentence]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return initial values for new session", () => {
+    const analyzer = new SessionAnalyzer(session);
+
+    expect(analyzer.getDuration()).toBe(0);
+    expect(analyzer.getTotalKeystrokes()).toBe(0);
+    expect(analyzer.getSuccessfulKeystrokes()).toBe(0);
+    expect(analyzer.getFailedKeystrokes()).toBe(0);
+    expect(analyzer.calcAccuracy()).toBe(0);
+    expect(analyzer.calcKps()).toBe(0);
+    expect(analyzer.calcCpm()).toBe(0);
+    expect(analyzer.isActive()).toBe(false);
+  });
+
+  it("should calculate values for active session", () => {
+    void session.currentSentence;
+
+    vi.advanceTimersByTime(10000);
+
+    const analyzer = new SessionAnalyzer(session);
+
+    expect(analyzer.getDuration()).toBe(10);
+    expect(analyzer.isActive()).toBe(true);
+  });
+
+  it("should calculate keystroke values correctly", () => {
+    const currentSentence = session.currentSentence;
+    const sentence = currentSentence!;
+    void sentence.currentCharacter;
+
+    const character = sentence.currentCharacter!;
+    character.inputLog.recordKeyInput("x", false);
+    character.inputLog.recordKeyInput("y", false);
+    sentence.inputCurrentCharacter("a");
+
+    const analyzer = new SessionAnalyzer(session);
+
+    expect(analyzer.getTotalKeystrokes()).toBe(3);
+    expect(analyzer.getSuccessfulKeystrokes()).toBe(1);
+    expect(analyzer.getFailedKeystrokes()).toBe(2);
+    expect(analyzer.calcAccuracy()).toBe(33.3);
+  });
+
+  it("should calculate KPS and CPM correctly", () => {
+    const currentSentence = session.currentSentence;
+    const sentence = currentSentence!;
+    void sentence.currentCharacter;
+
+    for (let i = 0; i < 5; i++) {
+      const char = sentence.currentCharacter;
+      if (char) {
+        char.inputLog.recordKeyInput("a", true);
+      }
+    }
+
+    vi.advanceTimersByTime(10000);
+
+    const analyzer = new SessionAnalyzer(session);
+
+    expect(analyzer.calcKps()).toBe(0.5);
+    expect(analyzer.calcCpm()).toBe(30);
+  });
+
+  it("should handle completed session", () => {
+    const currentSentence = session.currentSentence;
+    const sentence = currentSentence!;
+    void sentence.currentCharacter;
+    sentence.inputCurrentCharacter("a");
+    sentence.inputCurrentCharacter("i");
+    sentence.inputCurrentCharacter("u");
+
+    session.isCompleted();
+
+    const analyzer = new SessionAnalyzer(session);
+
+    expect(analyzer.isActive()).toBe(false);
+    expect(analyzer.getTotalKeystrokes()).toBe(3);
+    expect(analyzer.getSuccessfulKeystrokes()).toBe(3);
+    expect(analyzer.calcAccuracy()).toBe(100);
+  });
+
+  describe("individual methods", () => {
+    it("should calculate duration correctly", () => {
+      const analyzer = new SessionAnalyzer(session);
+      expect(analyzer.getDuration()).toBe(0);
+
+      void session.currentSentence;
+      vi.advanceTimersByTime(5500);
+
+      expect(analyzer.getDuration()).toBe(5.5);
+    });
+
+    it("should count keystrokes correctly", () => {
+      const analyzer = new SessionAnalyzer(session);
+      const sentence = session.currentSentence!;
+      void sentence.currentCharacter;
+
+      expect(analyzer.getTotalKeystrokes()).toBe(0);
+      expect(analyzer.getSuccessfulKeystrokes()).toBe(0);
+      expect(analyzer.getFailedKeystrokes()).toBe(0);
+
+      const character = sentence.currentCharacter!;
+      character.inputLog.recordKeyInput("x", false);
+      character.inputLog.recordKeyInput("a", true);
+
+      expect(analyzer.getTotalKeystrokes()).toBe(2);
+      expect(analyzer.getSuccessfulKeystrokes()).toBe(1);
+      expect(analyzer.getFailedKeystrokes()).toBe(1);
+    });
+
+    it("should calculate accuracy correctly", () => {
+      const analyzer = new SessionAnalyzer(session);
+      const sentence = session.currentSentence!;
+      void sentence.currentCharacter;
+
+      expect(analyzer.calcAccuracy()).toBe(0);
+
+      const character = sentence.currentCharacter!;
+      character.inputLog.recordKeyInput("a", true);
+      character.inputLog.recordKeyInput("b", false);
+      character.inputLog.recordKeyInput("c", true);
+
+      expect(analyzer.calcAccuracy()).toBe(66.7);
+    });
+
+    it("should calculate KPS correctly", () => {
+      const analyzer = new SessionAnalyzer(session);
+      const sentence = session.currentSentence!;
+      void sentence.currentCharacter;
+
+      expect(analyzer.calcKps()).toBe(0);
+
+      sentence.inputCurrentCharacter("a");
+      sentence.inputCurrentCharacter("i");
+      vi.advanceTimersByTime(2000);
+
+      expect(analyzer.calcKps()).toBe(1);
+    });
+
+    it("should calculate CPM correctly", () => {
+      const analyzer = new SessionAnalyzer(session);
+      const sentence = session.currentSentence!;
+      void sentence.currentCharacter;
+
+      expect(analyzer.calcCpm()).toBe(0);
+
+      sentence.inputCurrentCharacter("a");
+      sentence.inputCurrentCharacter("i");
+      sentence.inputCurrentCharacter("u");
+      vi.advanceTimersByTime(6000);
+
+      expect(analyzer.calcCpm()).toBe(30);
+    });
+
+    it("should check active status correctly", () => {
+      const analyzer = new SessionAnalyzer(session);
+
+      expect(analyzer.isActive()).toBe(false);
+
+      void session.currentSentence;
+      expect(analyzer.isActive()).toBe(true);
+
+      const sentence = session.currentSentence!;
+      sentence.inputCurrentCharacter("a");
+      sentence.inputCurrentCharacter("i");
+      sentence.inputCurrentCharacter("u");
+      session.isCompleted();
+
+      expect(analyzer.isActive()).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/session-analyzer.ts
+++ b/packages/core/src/session-analyzer.ts
@@ -1,0 +1,97 @@
+import type { Session } from "./session";
+
+export class SessionAnalyzer {
+  private readonly session: Session;
+
+  constructor(session: Session) {
+    this.session = session;
+  }
+
+  getDuration(): number {
+    const sessionLog = this.session.inputLog;
+    const startTime = sessionLog.startTime
+      ? new Date(sessionLog.startTime)
+      : null;
+
+    if (!startTime) {
+      return 0;
+    }
+
+    const endTime =
+      this.session.isCompleted() && sessionLog.endTime
+        ? new Date(sessionLog.endTime)
+        : new Date();
+
+    const elapsedTime = (endTime.getTime() - startTime.getTime()) / 1000;
+    return Math.round(elapsedTime * 10) / 10;
+  }
+
+  getTotalKeystrokes(): number {
+    let total = 0;
+    this.session.sentences.forEach((sentence) => {
+      sentence.characters.forEach((character) => {
+        total += character.inputLog.keyInputs.length;
+      });
+    });
+    return total;
+  }
+
+  getSuccessfulKeystrokes(): number {
+    let successful = 0;
+    this.session.sentences.forEach((sentence) => {
+      sentence.characters.forEach((character) => {
+        successful += character.inputLog.keyInputs.filter(
+          (input) => input.success,
+        ).length;
+      });
+    });
+    return successful;
+  }
+
+  getFailedKeystrokes(): number {
+    let failed = 0;
+    this.session.sentences.forEach((sentence) => {
+      sentence.characters.forEach((character) => {
+        failed += character.inputLog.keyInputs.filter(
+          (input) => !input.success,
+        ).length;
+      });
+    });
+    return failed;
+  }
+
+  calcAccuracy(): number {
+    const total = this.getTotalKeystrokes();
+    if (total === 0) {
+      return 0;
+    }
+    const successful = this.getSuccessfulKeystrokes();
+    const accuracy = (successful / total) * 100;
+    return Math.round(accuracy * 10) / 10;
+  }
+
+  calcKps(): number {
+    const duration = this.getDuration();
+    if (duration === 0) {
+      return 0;
+    }
+    const successful = this.getSuccessfulKeystrokes();
+    const kps = successful / duration;
+    return Math.round(kps * 10) / 10;
+  }
+
+  calcCpm(): number {
+    const duration = this.getDuration();
+    if (duration === 0) {
+      return 0;
+    }
+    const successful = this.getSuccessfulKeystrokes();
+    const cpm = successful / (duration / 60);
+    return Math.round(cpm * 10) / 10;
+  }
+
+  isActive(): boolean {
+    const sessionLog = this.session.inputLog;
+    return sessionLog.startTime !== null && !this.session.isCompleted();
+  }
+}


### PR DESCRIPTION
## Summary
- タイピング統計を計算するSessionAnalyzerクラスを追加
- セッション完了時に統計情報を表示するコンポーネントを実装
- ドメインロジックをコアパッケージに移動してアーキテクチャを改善

## Changes
- `SessionAnalyzer`クラスを作成し、個別の統計メソッドを提供
  - `getDuration()`: セッションの経過時間
  - `getTotalKeystrokes()`: 総打鍵数
  - `getSuccessfulKeystrokes()`: 成功した打鍵数
  - `getFailedKeystrokes()`: 失敗した打鍵数
  - `calcAccuracy()`: 正確性（％）
  - `calcKps()`: KPS（Keys Per Second）
  - `calcCpm()`: CPM（Characters Per Minute）
  - `isActive()`: セッションのアクティブ状態
- `TypingStatsDisplay`コンポーネントを追加し、統計情報を視覚的に表示
- セッション完了画面に統計表示を統合
- 包括的なテストカバレッジを追加

## Test plan
- [x] SessionAnalyzerの単体テストが全て成功
- [x] TypingStatsの単体テストが全て成功
- [x] ESLintエラーなし
- [x] TypeScriptの型チェックエラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)