### PR TITLE
refactor: remove sentence preview from start screen

### DIFF
--- a/apps/web/src/features/typing/components/session-input.tsx
+++ b/apps/web/src/features/typing/components/session-input.tsx
@@ -54,23 +54,6 @@ export function SessionInput({ sentences, onComplete }: SessionInputProps) {
             {allSentences.length}つの文章でタイピング練習を行います
           </p>
 
-          <div className="bg-secondary/30 rounded-2xl p-6 space-y-4">
-            <h3 className="text-lg font-semibold text-foreground mb-4">
-              練習する文章
-            </h3>
-            {allSentences.map((sentence, index) => (
-              <div
-                key={index}
-                className="text-left p-4 bg-background rounded-xl border border-border"
-              >
-                <div className="text-sm text-muted-foreground mb-2">
-                  文章 {index + 1}
-                </div>
-                <div className="text-lg">{sentence.label}</div>
-              </div>
-            ))}
-          </div>
-
           <Button onClick={start} size="lg" className="mt-6">
             タイピングを開始
           </Button>


### PR DESCRIPTION
## Summary
- Remove sentence preview from the start screen to create a simpler UX
- Users can now only see sentences after starting the session, preventing pre-reading

## Changes
- Removed the preview section (lines 57-72) from SessionInput component
- Sentences are still displayed after pressing the start button during typing practice
- Maintained all existing functionality for the typing session itself

## Closes
Closes #59

🤖 Generated with [Claude Code](https://claude.ai/code)