### PR TITLE
feat: add SentenceCollection class for organizing sentences

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./character";
 export * from "./character-input-log";
 export * from "./sentence";
+export * from "./sentence-collection";
 export * from "./sentence-factory";
 export * from "./sentence-input-log";
 export * from "./session";

--- a/packages/core/src/sentence-collection.test.ts
+++ b/packages/core/src/sentence-collection.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { SentenceCollection } from "./sentence-collection";
+import { createSentenceFactory } from "./sentence-factory";
+
+describe("SentenceCollection", () => {
+  const factory = createSentenceFactory();
+
+  it("should create a sentence collection with name, description, and sentences", () => {
+    const sentences = [
+      factory.fromText("こんにちは"),
+      factory.fromText("ありがとう"),
+    ];
+
+    const collection = new SentenceCollection({
+      name: "基本的な挨拶",
+      description: "日常的に使われる基本的な挨拶の練習",
+      sentences,
+    });
+
+    expect(collection.name).toBe("基本的な挨拶");
+    expect(collection.description).toBe("日常的に使われる基本的な挨拶の練習");
+    expect(collection.sentences).toEqual(sentences);
+    expect(collection.sentences.length).toBe(2);
+  });
+
+  it("should handle empty sentences array", () => {
+    const collection = new SentenceCollection({
+      name: "空のコレクション",
+      description: "文章が含まれていないコレクション",
+      sentences: [],
+    });
+
+    expect(collection.name).toBe("空のコレクション");
+    expect(collection.description).toBe("文章が含まれていないコレクション");
+    expect(collection.sentences).toEqual([]);
+    expect(collection.sentences.length).toBe(0);
+  });
+
+  it("should maintain sentence order", () => {
+    const sentence1 = factory.fromText("あいうえお");
+    const sentence2 = factory.fromText("かきくけこ");
+    const sentence3 = factory.fromText("さしすせそ");
+
+    const collection = new SentenceCollection({
+      name: "五十音順",
+      description: "五十音の順序で並んだ文章",
+      sentences: [sentence1, sentence2, sentence3],
+    });
+
+    expect(collection.sentences[0]).toBe(sentence1);
+    expect(collection.sentences[1]).toBe(sentence2);
+    expect(collection.sentences[2]).toBe(sentence3);
+  });
+});

--- a/packages/core/src/sentence-collection.ts
+++ b/packages/core/src/sentence-collection.ts
@@ -1,0 +1,31 @@
+import { Sentence } from "./sentence";
+
+type SentenceCollectionParams = {
+  name: string;
+  description: string;
+  sentences: Sentence[];
+};
+
+export class SentenceCollection {
+  private _name: string;
+  private _description: string;
+  private _sentences: Sentence[];
+
+  constructor({ name, description, sentences }: SentenceCollectionParams) {
+    this._name = name;
+    this._description = description;
+    this._sentences = sentences;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  get description(): string {
+    return this._description;
+  }
+
+  get sentences(): Sentence[] {
+    return this._sentences;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `SentenceCollection` class with `name`, `description`, and `sentences` properties
- Use object constructor pattern with `{ name, description, sentences }` parameters
- Enable structured organization of typing practice sentences

## Implementation Details
- **Class**: `SentenceCollection` in `packages/core/src/sentence-collection.ts`
- **Constructor**: Takes object parameter with required fields
- **Properties**: Read-only getters for name, description, and sentences
- **Tests**: Comprehensive test coverage including edge cases
- **Export**: Added to core package exports

## Test Coverage
- ✅ Basic functionality with name, description, and sentences
- ✅ Empty sentences array handling
- ✅ Sentence order preservation
- ✅ All tests passing

## Benefits
This foundation enables future enhancements:
- Multiple themed sentence sets (hiragana, katakana, vocabulary)
- Difficulty-based grouping
- Dynamic sentence selection and session building

## Closes
Closes #75

🤖 Generated with [Claude Code](https://claude.ai/code)