### PR TITLE
feat: add random sentence selection for typing practice

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,13 +1,17 @@
 "use client";
 
+import { SentenceCollection } from "@dakenjin/core";
 import { sentences } from "../sentences";
 import { SessionInput } from "../features/typing/components/session-input";
 
 export default function Home() {
+  const collections = Object.values(sentences);
+  const randomSentences = SentenceCollection.pick(collections, 10);
+
   return (
     <div className="min-h-[calc(100vh-4rem)] flex justify-center pt-20 p-4">
       <SessionInput
-        sentences={sentences.sample.sentences}
+        sentences={randomSentences}
         onComplete={() => console.log("セッション完了！")}
       />
     </div>

--- a/packages/core/src/sentence-collection.test.ts
+++ b/packages/core/src/sentence-collection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SentenceCollection } from "./sentence-collection";
 import { createSentenceFactory } from "./sentence-factory";
 
@@ -50,5 +50,153 @@ describe("SentenceCollection", () => {
     expect(collection.sentences[0]).toBe(sentence1);
     expect(collection.sentences[1]).toBe(sentence2);
     expect(collection.sentences[2]).toBe(sentence3);
+  });
+
+  describe("pick", () => {
+    let mockRandom: any;
+
+    beforeEach(() => {
+      mockRandom = vi.spyOn(Math, "random");
+    });
+
+    afterEach(() => {
+      mockRandom.mockRestore();
+    });
+
+    it("should return all sentences when count is greater than available sentences", () => {
+      const collection1 = new SentenceCollection({
+        name: "Collection 1",
+        description: "Test collection 1",
+        sentences: [
+          factory.fromText("あいうえお"),
+          factory.fromText("かきくけこ"),
+        ],
+      });
+
+      const collection2 = new SentenceCollection({
+        name: "Collection 2",
+        description: "Test collection 2",
+        sentences: [factory.fromText("さしすせそ")],
+      });
+
+      const result = SentenceCollection.pick([collection1, collection2], 5);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((s) => s.label)).toEqual([
+        "あいうえお",
+        "かきくけこ",
+        "さしすせそ",
+      ]);
+    });
+
+    it("should pick random sentences without duplication", () => {
+      const collection = new SentenceCollection({
+        name: "Test Collection",
+        description: "Test collection",
+        sentences: [
+          factory.fromText("あいうえお"),
+          factory.fromText("かきくけこ"),
+          factory.fromText("さしすせそ"),
+          factory.fromText("たちつてと"),
+          factory.fromText("なにぬねの"),
+        ],
+      });
+
+      mockRandom
+        .mockReturnValueOnce(0.1) // index 0
+        .mockReturnValueOnce(0.9) // index 4
+        .mockReturnValueOnce(0.5); // index 2
+
+      const result = SentenceCollection.pick([collection], 3);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((s) => s.label)).toEqual([
+        "あいうえお",
+        "なにぬねの",
+        "さしすせそ",
+      ]);
+    });
+
+    it("should handle duplicate random indices correctly", () => {
+      const collection = new SentenceCollection({
+        name: "Test Collection",
+        description: "Test collection",
+        sentences: [
+          factory.fromText("あいうえお"),
+          factory.fromText("かきくけこ"),
+          factory.fromText("さしすせそ"),
+        ],
+      });
+
+      mockRandom
+        .mockReturnValueOnce(0.1) // index 0
+        .mockReturnValueOnce(0.1) // index 0 (duplicate, should be skipped)
+        .mockReturnValueOnce(0.5) // index 1
+        .mockReturnValueOnce(0.9); // index 2
+
+      const result = SentenceCollection.pick([collection], 3);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((s) => s.label)).toEqual([
+        "あいうえお",
+        "かきくけこ",
+        "さしすせそ",
+      ]);
+    });
+
+    it("should pick from multiple collections", () => {
+      const collection1 = new SentenceCollection({
+        name: "Collection 1",
+        description: "Test collection 1",
+        sentences: [
+          factory.fromText("あいうえお"),
+          factory.fromText("かきくけこ"),
+        ],
+      });
+
+      const collection2 = new SentenceCollection({
+        name: "Collection 2",
+        description: "Test collection 2",
+        sentences: [
+          factory.fromText("さしすせそ"),
+          factory.fromText("たちつてと"),
+        ],
+      });
+
+      mockRandom
+        .mockReturnValueOnce(0.1) // index 0 (Collection 1 - Sentence 1)
+        .mockReturnValueOnce(0.7) // index 2 (Collection 2 - Sentence 1)
+        .mockReturnValueOnce(0.9); // index 3 (Collection 2 - Sentence 2)
+
+      const result = SentenceCollection.pick([collection1, collection2], 3);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((s) => s.label)).toEqual([
+        "あいうえお",
+        "さしすせそ",
+        "たちつてと",
+      ]);
+    });
+
+    it("should return empty array when count is 0", () => {
+      const collection = new SentenceCollection({
+        name: "Test Collection",
+        description: "Test collection",
+        sentences: [
+          factory.fromText("あいうえお"),
+          factory.fromText("かきくけこ"),
+        ],
+      });
+
+      const result = SentenceCollection.pick([collection], 0);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("should handle empty collections array", () => {
+      const result = SentenceCollection.pick([], 5);
+
+      expect(result).toHaveLength(0);
+    });
   });
 });

--- a/packages/core/src/sentence-collection.ts
+++ b/packages/core/src/sentence-collection.ts
@@ -28,4 +28,27 @@ export class SentenceCollection {
   get sentences(): Sentence[] {
     return this._sentences;
   }
+
+  static pick(collections: SentenceCollection[], count: number): Sentence[] {
+    const allSentences = collections.flatMap(
+      (collection) => collection.sentences,
+    );
+
+    if (allSentences.length <= count) {
+      return allSentences;
+    }
+
+    const picked: Sentence[] = [];
+    const indices = new Set<number>();
+
+    while (picked.length < count) {
+      const randomIndex = Math.floor(Math.random() * allSentences.length);
+      if (!indices.has(randomIndex)) {
+        indices.add(randomIndex);
+        picked.push(allSentences[randomIndex]);
+      }
+    }
+
+    return picked;
+  }
 }


### PR DESCRIPTION
## Summary
- Implement `SentenceCollection.pick` static method to randomly select sentences from multiple collections
- Update homepage to show 10 random sentences from all available collections instead of fixed sample sentences

## Changes
- Add `SentenceCollection.pick(collections, count)` method that:
  - Takes an array of SentenceCollection instances
  - Returns specified number of random sentences without duplication
  - Returns all sentences if requested count exceeds available sentences
- Add comprehensive test coverage with mocked `Math.random` for deterministic testing
- Update `apps/web/src/app/page.tsx` to use the new random selection feature

## Test plan
- [x] Unit tests for `SentenceCollection.pick` method covering:
  - Random selection without duplication
  - Handling when requested count exceeds available sentences
  - Selecting from multiple collections
  - Edge cases (empty collections, count = 0)
- [x] Run `pnpm ready` - all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)