### PR TITLE
feat: add spacebar to start typing on homepage

### DIFF
--- a/apps/web/src/features/typing/components/session-input.tsx
+++ b/apps/web/src/features/typing/components/session-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Progress, Button } from "../../../ui/components";
 import { Sentence } from "@dakenjin/core";
 import { useSession } from "@dakenjin/react";
@@ -42,6 +42,25 @@ export function SessionInput({ sentences, onComplete }: SessionInputProps) {
 
   const currentSentenceIndex = completedSentences.length;
 
+  useEffect(() => {
+    if (session.isStarted) {
+      return;
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.code === "Space") {
+        e.preventDefault();
+        start();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [session.isStarted, start]);
+
   if (!session.isStarted) {
     return (
       <div className="w-full max-w-3xl">
@@ -57,6 +76,10 @@ export function SessionInput({ sentences, onComplete }: SessionInputProps) {
           <Button onClick={start} size="lg" className="mt-6">
             タイピングを開始
           </Button>
+
+          <p className="text-sm text-muted-foreground mt-4">
+            スペースキーを押しても開始できます
+          </p>
 
           <div className="mt-6">
             <BetaNotice />


### PR DESCRIPTION
## Summary
Implement keyboard support to start typing practice by pressing the spacebar on the homepage, providing a more seamless experience for keyboard-focused users.

## Changes
- Add `useEffect` hook in `SessionInput` component to listen for spacebar key events
- Only listen when session is not started to avoid interference with typing
- Prevent default spacebar behavior (page scroll) when starting session
- Add helper text "スペースキーを押しても開始できます" below the start button
- Properly clean up event listener when session starts or component unmounts

## Test plan
- [x] Run `pnpm ready` - all tests pass
- [x] Manually tested:
  - Pressing spacebar on homepage starts the typing session
  - Spacebar doesn't interfere once typing has started
  - Event listener is properly cleaned up
  - Button click still works as before

Closes #81

🤖 Generated with [Claude Code](https://claude.ai/code)