### PR TITLE
feat: widen beta notice card width

### DIFF
--- a/apps/web/src/features/typing/components/beta-notice.tsx
+++ b/apps/web/src/features/typing/components/beta-notice.tsx
@@ -2,7 +2,7 @@ import { AlertTriangle, ExternalLink } from "lucide-react";
 
 export function BetaNotice() {
   return (
-    <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-xl p-3 sm:p-4 max-w-md mx-auto">
+    <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-xl p-3 sm:p-4 max-w-lg mx-auto">
       <div className="flex items-start gap-2 sm:gap-3">
         <AlertTriangle className="w-4 h-4 sm:w-5 sm:h-5 text-amber-600 dark:text-amber-500 shrink-0 mt-0.5" />
         <div className="space-y-1.5 sm:space-y-2 text-xs sm:text-sm">


### PR DESCRIPTION
## Summary
ベータ版注釈カードの横幅を `max-w-md` (448px) から `max-w-lg` (512px) に広げました。

## Changes
- `beta-notice.tsx` のコンテナの最大幅を変更
  - 変更前: `max-w-md` (28rem / 448px)
  - 変更後: `max-w-lg` (32rem / 512px)
  - 差分: +64px (4rem) の横幅拡張

## Test plan
- [x] `pnpm ready` - 全テスト成功
- [x] レスポンシブデザインは維持（`mx-auto` でセンタリング）

## Screenshots
変更内容：
- より広い横幅で、テキストがより読みやすくなります
- モバイルビューでは変更なし（既存のレスポンシブ設計を維持）

Closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)