### PR TITLE
fix: replace unnatural "エーピーアイ" (API) input in programming conversation

### DIFF
--- a/apps/web/src/sentences/programming-conversation.ts
+++ b/apps/web/src/sentences/programming-conversation.ts
@@ -31,8 +31,8 @@ export const programmingConversation = new SentenceCollection({
       "パフォーマンスの改善が必要です",
     ),
     factory.fromText(
-      "エーピーアイのしようしょをかくにんしてください",
-      "APIの仕様書を確認してください",
+      "がいぶれんけいのしようをかくにんしてください",
+      "外部連携の仕様を確認してください",
     ),
     factory.fromText(
       "リファクタリングのじかんをとりましょう",


### PR DESCRIPTION
## Summary
- Replaced unnatural phonetic spelling "エーピーアイ" (API) with "外部連携の仕様" (external integration specifications)
- This provides a more natural typing experience for Japanese users

## Problem
Japanese users don't typically spell out English acronyms phonetically when typing. The sentence "エーピーアイのしようしょをかくにんしてください" feels unnatural and doesn't reflect real-world typing scenarios.

## Solution
Changed the sentence to "がいぶれんけいのしようをかくにんしてください" (外部連携の仕様を確認してください), which maintains the same technical context while using natural Japanese vocabulary.

## Test plan
- [x] All existing tests pass
- [x] The new sentence uses only Japanese characters
- [x] The sentence maintains programming context

Closes #89

🤖 Generated with [Claude Code](https://claude.ai/code)