### PR TITLE
fix: require double 'n' input when 'ん' is followed by vowels

### DIFF
--- a/packages/core/src/characters/japanese.ts
+++ b/packages/core/src/characters/japanese.ts
@@ -6,6 +6,19 @@ const createNInputPatternResolver = (): InputPatternResolver => {
     if (context.next && context.next.getPreview(context).startsWith("n")) {
       return ["nn"];
     }
+    // 次の文字が母音（あ行）の場合は "nn" のみ
+    if (context.next) {
+      const nextPreview = context.next.getPreview(context);
+      if (
+        nextPreview.startsWith("a") ||
+        nextPreview.startsWith("i") ||
+        nextPreview.startsWith("u") ||
+        nextPreview.startsWith("e") ||
+        nextPreview.startsWith("o")
+      ) {
+        return ["nn"];
+      }
+    }
     // 文章の最後の場合は "nn" のみ
     if (!context.next) {
       return ["nn"];

--- a/packages/core/src/contextual-input-patterns.test.ts
+++ b/packages/core/src/contextual-input-patterns.test.ts
@@ -157,6 +157,48 @@ describe("Contextual Input Patterns", () => {
       const contextEnd = { prev: sentence.characters[0], next: null };
       expect(nnChar.getInputPatterns(contextEnd)).toEqual(["nn"]);
     });
+
+    it("should require nn when ん is followed by vowels", () => {
+      // Test with あ
+      const sentenceA = factory.fromText("こんあん");
+      const nnChar1 = sentenceA.characters[1]; // first "ん"
+      const aChar = sentenceA.characters[2]; // "あ"
+
+      const contextA = { prev: sentenceA.characters[0], next: aChar };
+      expect(nnChar1.getInputPatterns(contextA)).toEqual(["nn"]);
+
+      // Test with い
+      const sentenceI = factory.fromText("しんいん");
+      const nnCharI = sentenceI.characters[1]; // "ん"
+      const iChar = sentenceI.characters[2]; // "い"
+
+      const contextI = { prev: sentenceI.characters[0], next: iChar };
+      expect(nnCharI.getInputPatterns(contextI)).toEqual(["nn"]);
+
+      // Test with う
+      const sentenceU = factory.fromText("さんう");
+      const nnCharU = sentenceU.characters[1]; // "ん"
+      const uChar = sentenceU.characters[2]; // "う"
+
+      const contextU = { prev: sentenceU.characters[0], next: uChar };
+      expect(nnCharU.getInputPatterns(contextU)).toEqual(["nn"]);
+
+      // Test with え
+      const sentenceE = factory.fromText("けんえき");
+      const nnCharE = sentenceE.characters[1]; // "ん"
+      const eChar = sentenceE.characters[2]; // "え"
+
+      const contextE = { prev: sentenceE.characters[0], next: eChar };
+      expect(nnCharE.getInputPatterns(contextE)).toEqual(["nn"]);
+
+      // Test with お
+      const sentenceO = factory.fromText("きんおう");
+      const nnCharO = sentenceO.characters[1]; // "ん"
+      const oChar = sentenceO.characters[2]; // "お"
+
+      const contextO = { prev: sentenceO.characters[0], next: oChar };
+      expect(nnCharO.getInputPatterns(contextO)).toEqual(["nn"]);
+    });
   });
 
   describe("Sentence with contextual patterns", () => {


### PR DESCRIPTION
## Summary
- Fix input behavior for 'ん' when followed by vowels (あ、い、う、え、お)
- Now requires "nn" input to prevent ambiguous interpretations

## Problem
Previously, when typing words like "こんあん", the input "konan" could be ambiguously interpreted. This fix ensures that 'ん' before vowels must be typed as "nn".

## Solution
Updated `createNInputPatternResolver` to check if the next character starts with a vowel and require "nn" in those cases.

## Examples
- こんあん → `konnann` (not `konan`)
- しんいん → `shinninn` (not `shinin`)
- げんいん → `genninn` (not `genin`)

## Test plan
- [x] Added comprehensive test cases for all vowels (a, i, u, e, o)
- [x] All existing tests pass
- [x] Manual testing confirms the fix works as expected

Fixes #100

🤖 Generated with [Claude Code](https://claude.ai/code)